### PR TITLE
Add the possibility to fetch a parameter from its unique id

### DIFF
--- a/src/collections/Parameters.php
+++ b/src/collections/Parameters.php
@@ -8,44 +8,44 @@ use phootwork\lang\Arrayable;
 use gossi\swagger\Parameter;
 
 class Parameters implements Arrayable, \Iterator {
-	
+
 	use RefPart;
-	
+
 	/** @var ArrayList */
 	private $parameters;
-	
+
 	public function __construct($contents = []) {
 		$this->parse($contents === null ? [] : $contents);
 	}
-	
+
 	private function parse($contents) {
 		$data = CollectionUtils::toMap($contents);
-		
+
 		$this->parameters = new ArrayList();
 		$this->parseRef($data);
-		
+
 		if (!$this->hasRef()) {
 			foreach ($data as $param) {
 				$this->parameters->add(new Parameter($param));
 			}
 		}
 	}
-	
+
 	public function toArray() {
 		if ($this->hasRef()) {
 			return ['$ref' => $this->getRef()];
 		}
-		
+
 		return $this->parameters->toArray();
 	}
-	
+
 	public function size() {
 		return $this->parameters->size();
 	}
 
 	/**
 	 * Searches whether a parameter with the given name exists
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -54,10 +54,10 @@ class Parameters implements Arrayable, \Iterator {
 			return $param->getName() == $name;
 		});
 	}
-	
+
 	/**
 	 * Returns parameter with the given name if it exists
-	 * 
+	 *
 	 * @param string $name
 	 * @return Parameter|void
 	 */
@@ -68,11 +68,11 @@ class Parameters implements Arrayable, \Iterator {
 			}
 		}
 	}
-	
+
 	/**
 	 * Searches for the parameter with the given name. Creates a parameter with the given name
 	 * if none exists
-	 * 
+	 *
 	 * @param string $name
 	 * @return Parameter
 	 */
@@ -83,54 +83,87 @@ class Parameters implements Arrayable, \Iterator {
 			$param->setName($name);
 			$this->parameters->add($param);
 		}
-		
+
 		return $param;
 	}
-	
+
+	/**
+	 * Searches whether a parameter with the given unique combination exists
+	 *
+	 * @param string $name
+	 * @param string $id
+	 * @return boolean
+	 */
+	public function search($name, $in) {
+		return $this->parameters->search(function(Parameter $param) use ($name, $in) {
+			return $param->getIn() == $in && $param->getName() == $name;
+		});
+	}
+
+	public function find($name, $in) {
+		foreach ($this->parameters as $param) {
+			if ($param->getIn() == $in && $param->getName() == $name) {
+				return $param;
+			}
+		}
+	}
+
+	public function get($name, $in) {
+		$param = $this->find($name, $in);
+		if (empty($param)) {
+			$param = new Parameter();
+			$param->setName($name);
+			$param->setIn($in);
+			$this->parameters->add($param);
+		}
+
+		return $param;
+	}
+
 	/**
 	 * Adds a parameter
-	 * 
+	 *
 	 * @param Parameter $param
 	 */
 	public function add(Parameter $param) {
 		$this->parameters->add($param);
 	}
-	
+
 	/**
 	 * Removes a parameter
-	 * 
+	 *
 	 * @param Parameter $param
 	 */
 	public function remove(Parameter $param) {
 		$this->parameters->remove($param);
 	}
-	
+
 	/**
 	 * Returns whether a given parameter exists
-	 * 
+	 *
 	 * @param Parameter $param
 	 * @return boolean
 	 */
 	public function contains(Parameter $param) {
 		return $this->parameters->contains($param);
 	}
-	
+
 	public function current() {
 		return $this->parameters->current();
 	}
-	
+
 	public function key() {
 		return $this->parameters->key();
 	}
-	
+
 	public function next() {
 		return $this->parameters->next();
 	}
-	
+
 	public function rewind() {
 		return $this->parameters->rewind();
 	}
-	
+
 	public function valid() {
 		return $this->parameters->valid();
 	}

--- a/tests/CollectionsTest.php
+++ b/tests/CollectionsTest.php
@@ -13,15 +13,15 @@ use gossi\swagger\collections\Responses;
 use gossi\swagger\Response;
 
 class CollectionsTest extends \PHPUnit_Framework_TestCase {
-	
+
 	public function testDefinitions() {
 		$swagger = new Swagger();
 		$definitions = $swagger->getDefinitions();
-		
+
 		$this->assertTrue($definitions instanceof Definitions);
 		$this->assertEquals(0, $definitions->size());
 		$this->assertFalse($definitions->has('User'));
-		
+
 		$user = new Schema();
 		$definitions->set('User', $user);
 		$this->assertEquals(1, $definitions->size());
@@ -29,69 +29,90 @@ class CollectionsTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($definitions->get('User') instanceof Schema);
 		$this->assertSame($user, $definitions->get('User'));
 		$this->assertTrue($definitions->contains($user));
-		
+
 		$definitions->remove('User');
 		$this->assertEquals(0, $definitions->size());
 		$this->assertFalse($definitions->has('User'));
 	}
-	
+
 	public function testPaths() {
 		$swagger = new Swagger();
 		$paths = $swagger->getPaths();
-		
+
 		$this->assertTrue($paths instanceof Paths);
 		$this->assertEquals(0, $paths->size());
 		$this->assertFalse($paths->has('/pets'));
-		
+
 		$pets = new Path('/pets');
 		$paths->add($pets);
-		
+
 		$this->assertEquals(1, $paths->size());
 		$this->assertTrue($paths->has('/pets'));
 		$this->assertTrue($paths->get('/pets') instanceof Path);
 		$this->assertSame($pets, $paths->get('/pets'));
 		$this->assertTrue($paths->contains($pets));
-		
+
 		$paths->remove('/pets');
 		$this->assertEquals(0, $paths->size());
 		$this->assertFalse($paths->has('/pets'));
 	}
-	
+
 	public function testParameters() {
 		$path = new Path('/pets');
 		$parameters = $path->getOperation('get')->getParameters();
-		
+
 		$this->assertTrue($parameters instanceof Parameters);
 		$this->assertEquals(0, $parameters->size());
 		$this->assertFalse($parameters->searchByName('id'));
 		$this->assertEmpty($parameters->findByName('id'));
-		
+
 		$id = new Parameter();
 		$id->setName('id');
+		$id->setIn('path');
 		$parameters->add($id);
 		$this->assertEquals(1, $parameters->size());
 		$this->assertTrue($parameters->searchByName('id'));
+		$this->assertTrue($parameters->search('id', 'path'));
 		$this->assertTrue($parameters->findByName('id') instanceof Parameter);
+		$this->assertTrue($parameters->find('id', 'path') instanceof Parameter);
+		$this->assertFalse($parameters->find('id', 'body') instanceof Parameter);
 		$this->assertSame($id, $parameters->findByName('id'));
 		$this->assertTrue($parameters->contains($id));
-		
+
+		$id2 = new Parameter();
+		$id2->setName('id');
+		$id2->setIn('body');
+		$parameters->add($id2);
+		$this->assertEquals(2, $parameters->size());
+		$this->assertTrue($parameters->search('id', 'body'));
+		$this->assertTrue($parameters->find('id', 'body') instanceof Parameter);
+		$this->assertSame($id, $parameters->find('id', 'path'));
+		$this->assertSame($id2, $parameters->find('id', 'body'));
+		$this->assertTrue($parameters->contains($id));
+
+		$parameter = $parameters->get('bar', 'query');
+		$this->assertEquals('bar', $parameter->getName());
+		$this->assertEquals('query', $parameter->getIn());
+
 		$parameters->remove($id);
+		$parameters->remove($id2);
+		$parameters->remove($parameter);
 		$this->assertEquals(0, $parameters->size());
 		$this->assertFalse($parameters->searchByName('id'));
-		
+
 		// test $ref
 		$parameters->setRef('#/definitions/id');
 		$this->assertEquals(['$ref' => '#/definitions/id'], $parameters->toArray());
 	}
-	
+
 	public function testResponses() {
 		$operation = new Operation();
 		$responses = $operation->getResponses();
-		
+
 		$this->assertTrue($responses instanceof Responses);
 		$this->assertEquals(0, $responses->size());
 		$this->assertFalse($responses->has('200'));
-		
+
 		$ok = new Response('200');
 		$responses->add($ok);
 		$this->assertEquals(1, $responses->size());
@@ -99,7 +120,7 @@ class CollectionsTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($responses->get('200') instanceof Response);
 		$this->assertSame($ok, $responses->get('200'));
 		$this->assertTrue($responses->contains($ok));
-		
+
 		$responses->remove('200');
 		$this->assertEquals(0, $responses->size());
 		$this->assertFalse($responses->has('200'));


### PR DESCRIPTION
As stated in the swagger specification http://swagger.io/specification/#parameterObject, a parameter is identified by the combination of its name and of its location.

So it would be great to add the possibility to easily find one :-)
