### PR TITLE
Allow to merge models

### DIFF
--- a/src/Contact.php
+++ b/src/Contact.php
@@ -2,6 +2,7 @@
 namespace gossi\swagger;
 
 use gossi\swagger\parts\ExtensionPart;
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\CollectionUtils;
 use phootwork\lang\Arrayable;
 
@@ -31,6 +32,17 @@ class Contact extends AbstractModel implements Arrayable {
 
 		// extensions
 		$this->parseExtensions($data);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function merge(static $model, $overwrite = false) {
+		MergeHelper::mergeFields($this->name, $model->name, $overwrite);
+		MergeHelper::mergeFields($this->url, $model->url, $overwrite);
+		MergeHelper::mergeFields($this->email, $model->email, $overwrite);
+
+		$this->mergeExtensions($model, $overwrite);
 	}
 
 	public function toArray() {

--- a/src/ExternalDocs.php
+++ b/src/ExternalDocs.php
@@ -26,6 +26,15 @@ class ExternalDocs extends AbstractModel implements Arrayable {
 		$this->parseExtensions($data);
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
+	public function merge(static $model, $overwrite = false) {
+		$this->mergeDescription($model, $overwrite);
+		$this->mergeUrl($model, $overwrite);
+		$this->mergeExtensions($model, $overwrite);
+	}
+
 	public function toArray() {
 		return $this->export('description', 'url');
 	}

--- a/src/Header.php
+++ b/src/Header.php
@@ -19,9 +19,9 @@ class Header extends AbstractModel implements Arrayable {
 	/** @var string */
 	private $header;
 
-	public function __construct($header, $contents = null) {
+	public function __construct($header, $contents = []) {
 		$this->header = $header;
-		$this->parse($contents === null ? new Map() : $contents);
+		$this->parse($contents);
 	}
 
 	private function parse($contents = []) {
@@ -34,13 +34,27 @@ class Header extends AbstractModel implements Arrayable {
 		$this->parseExtensions($data);
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
+	public function merge(static $model, $overwrite = false) {
+		if ($this->header !== $model->header) {
+			throw new \InvalidArgumentException(sprintf('You can\'t merge two different headers (provided "%s" and "%s").', $this->header, $model->header));
+		}
+
+		$this->mergeDescription($model, $overwrite);
+		$this->mergeType($model, $overwrite);
+		$this->mergeItems($model, $overwrite);
+		$this->mergeExtensions($model, $overwrite);
+	}
+
 	public function toArray() {
 		return $this->export('description', $this->getTypeExportFields(), 'items');
 	}
 
 	/**
 	 * Returns the header
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getHeader() {

--- a/src/parts/ConsumesPart.php
+++ b/src/parts/ConsumesPart.php
@@ -1,6 +1,7 @@
 <?php
 namespace gossi\swagger\parts;
 
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\Map;
 use phootwork\collection\Set;
 
@@ -10,6 +11,10 @@ trait ConsumesPart {
 
 	private function parseConsumes(Map $data) {
 		$this->consumes = $data->get('consumes', new Set());
+	}
+
+	private function mergeConsumes(static $model, $overwrite = false) {
+		MergeHelper::mergeFields($this->consumes, $model->consumes, $overwrite);
 	}
 
 	/**

--- a/src/parts/DescriptionPart.php
+++ b/src/parts/DescriptionPart.php
@@ -1,20 +1,25 @@
 <?php
 namespace gossi\swagger\parts;
 
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\Map;
 
 trait DescriptionPart {
 
-	/** @var string */
-	private $description = false;
+	/** @var string|null */
+	private $description;
 
 	private function parseDescription(Map $data) {
 		$this->description = $data->get('description');
 	}
 
+	private function mergeDescription(static $model, $overwrite = false) {
+		MergeHelper::mergeFields($this->description, $model->description, $overwrite);
+	}
+
 	/**
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public function getDescription() {
 		return $this->description;
@@ -22,7 +27,7 @@ trait DescriptionPart {
 
 	/**
 	 *
-	 * @param string $description
+	 * @param string|null $description
 	 * @return $this
 	 */
 	public function setDescription($description) {

--- a/src/parts/ExtensionPart.php
+++ b/src/parts/ExtensionPart.php
@@ -1,6 +1,7 @@
 <?php
 namespace gossi\swagger\parts;
 
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\Map;
 use phootwork\lang\Text;
 
@@ -19,9 +20,13 @@ trait ExtensionPart {
 		}
 	}
 
+	private function mergeExtensions(static $model, $overwrite = false) {
+		MergeHelper::mergeFields($this->extensions, $model->description, $overwrite);
+	}
+
 	/**
 	 * Returns extensions
-	 * 
+	 *
 	 * @return Map
 	 */
 	public function getExtensions() {

--- a/src/parts/ExternalDocsPart.php
+++ b/src/parts/ExternalDocsPart.php
@@ -12,6 +12,10 @@ trait ExternalDocsPart {
 		$this->externalDocs = new ExternalDocs($data->get('externalDocs', new Map()));
 	}
 
+	private function mergeExternalDocs(static $model, $overwrite = false) {
+		$this->externalDocs->merge($model->externalDocs, $overwrite);
+	}
+
 	/**
 	 *
 	 * @return ExternalDocs
@@ -22,8 +26,8 @@ trait ExternalDocsPart {
 
 	/**
 	 *
-	 * @param ExternalDocs $externalDocs   
-	 * @return $this     	
+	 * @param ExternalDocs $externalDocs
+	 * @return $this
 	 */
 	public function setExternalDocs(ExternalDocs $externalDocs) {
 		$this->externalDocs = $externalDocs;

--- a/src/parts/ItemsPart.php
+++ b/src/parts/ItemsPart.php
@@ -3,6 +3,7 @@
 namespace gossi\swagger\parts;
 
 use gossi\swagger\Items;
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\Map;
 
 trait ItemsPart {
@@ -16,9 +17,17 @@ trait ItemsPart {
 		}
 	}
 
+	private function mergeItems(static $model, $overwrite = false) {
+		if (null === $this->items) {
+			$this->items = clone $model->items;
+		} elseif (null !== $model->items) {
+			$this->items->merge($model->items, $overwrite);
+		}
+	}
+
 	/**
 	 * Returns the items
-	 * 
+	 *
 	 * @return Items
 	 */
 	public function getItems() {

--- a/src/parts/ParametersPart.php
+++ b/src/parts/ParametersPart.php
@@ -2,6 +2,7 @@
 namespace gossi\swagger\parts;
 
 use gossi\swagger\collections\Parameters;
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\Map;
 
 trait ParametersPart {
@@ -11,6 +12,10 @@ trait ParametersPart {
 
 	private function parseParameters(Map $data) {
 		$this->parameters = new Parameters($data->get('parameters', new Map()));
+	}
+
+	private function mergeParameters(static $model, $overwrite = false) {
+		$this->parameters->merge($model, $overwrite);
 	}
 
 	/**

--- a/src/parts/ProducesPart.php
+++ b/src/parts/ProducesPart.php
@@ -1,6 +1,7 @@
 <?php
 namespace gossi\swagger\parts;
 
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\Map;
 use phootwork\collection\Set;
 
@@ -10,6 +11,10 @@ trait ProducesPart {
 
 	private function parseProduces(Map $data) {
 		$this->produces = $data->get('produces', new Set());
+	}
+
+	private function mergeProduces(static $model, $overwrite = false) {
+		MergeHelper::mergeFields($this->produces, $model->produces, $overwrite);
 	}
 
 	/**

--- a/src/parts/RefPart.php
+++ b/src/parts/RefPart.php
@@ -1,6 +1,7 @@
 <?php
 namespace gossi\swagger\parts;
 
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\Map;
 
 trait RefPart {
@@ -8,12 +9,12 @@ trait RefPart {
 	/** @var string */
 	private $ref;
 
-	/** @var bool */
-	private $hasRef = false;
-
 	private function parseRef(Map $data) {
 		$this->ref = $data->get('$ref');
-		$this->hasRef = $data->has('$ref');
+	}
+
+	private function mergeRef(static $model, $overwrite = false) {
+		MergeHelper::mergeFields($this->ref, $model->ref, $overwrite);
 	}
 
 	/**
@@ -31,12 +32,11 @@ trait RefPart {
 	 */
 	public function setRef($ref) {
 		$this->ref = $ref;
-		$this->hasRef = $ref !== null;
 		return $this;
 	}
 
 	public function hasRef() {
-		return $this->hasRef;
+		return null !== $this->ref;
 	}
 
 }

--- a/src/parts/RequiredPart.php
+++ b/src/parts/RequiredPart.php
@@ -1,15 +1,20 @@
 <?php
 namespace gossi\swagger\parts;
 
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\Map;
 
 trait RequiredPart {
 
 	/** @var bool */
-	private $required = false;
+	private $required;
 
 	private function parseRequired(Map $data) {
-		$this->required = $data->has('required') && $data->get('required');
+		$this->required = $data->get('required');
+	}
+
+	private function mergeRequired(static $model, $overwrite = false) {
+		MergeHelper::mergeFields($this->required, $model->required, $overwrite);
 	}
 
 	/**
@@ -17,12 +22,12 @@ trait RequiredPart {
 	 * @return bool
 	 */
 	public function getRequired() {
-		return $this->required;
+		return null !== $this->required ? $this->required : false;
 	}
 
 	/**
 	 *
-	 * @param bool $required
+	 * @param bool|null $required
 	 * @return $this
 	 */
 	public function setRequired($required) {

--- a/src/parts/ResponsesPart.php
+++ b/src/parts/ResponsesPart.php
@@ -2,6 +2,7 @@
 namespace gossi\swagger\parts;
 
 use gossi\swagger\collections\Responses;
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\Map;
 
 trait ResponsesPart {
@@ -11,6 +12,10 @@ trait ResponsesPart {
 
 	private function parseResponses(Map $data) {
 		$this->responses = new Responses($data->get('responses', new Map()));
+	}
+
+	private function mergeResponses(static $model, $overwrite = false) {
+		$this->responses->merge($model->responses, $overwrite);
 	}
 
 	/**

--- a/src/parts/SchemaPart.php
+++ b/src/parts/SchemaPart.php
@@ -2,6 +2,7 @@
 namespace gossi\swagger\parts;
 
 use gossi\swagger\Schema;
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\Map;
 
 trait SchemaPart {
@@ -11,6 +12,10 @@ trait SchemaPart {
 
 	private function parseSchema(Map $data) {
 		$this->schema = new Schema($data->get('schema'));
+	}
+
+	private function mergeSchema(static $model, $overwrite = false) {
+		$this->schema->merge($model->schema, $overwrite);
 	}
 
 	/**

--- a/src/parts/SchemesPart.php
+++ b/src/parts/SchemesPart.php
@@ -1,6 +1,7 @@
 <?php
 namespace gossi\swagger\parts;
 
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\ArrayList;
 use phootwork\collection\Map;
 
@@ -10,6 +11,10 @@ trait SchemesPart {
 
 	private function parseSchemes(Map $data) {
 		$this->schemes = $data->get('schemes', new ArrayList());
+	}
+
+	private function mergeSchemes(static $model, $overwrite = false) {
+		$this->schemes->addAll($model->schemes);
 	}
 
 	/**

--- a/src/parts/TagsPart.php
+++ b/src/parts/TagsPart.php
@@ -2,6 +2,7 @@
 namespace gossi\swagger\parts;
 
 use gossi\swagger\Tag;
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\ArrayList;
 use phootwork\collection\Map;
 
@@ -14,6 +15,23 @@ trait TagsPart {
 		foreach ($data->get('tags', []) as $t) {
 			$this->tags->add(new Tag($t));
 		}
+	}
+
+	private function mergeTags(static $model, $overwrite = false) {
+		$newTags = [];
+		foreach ($model->tags as $tag) {
+			$find = $this->tags->find(function(Tag $element) use ($tag) {
+				return $tag->getName() === $element->getName();
+			});
+
+			if (null !== $find) {
+				$find->merge($tag, $overwrite);
+			} else {
+				$newTags[] = new Tag($tag->toArray());
+			}
+		}
+
+		$this->tags->addAll($newTags);
 	}
 
 	/**

--- a/src/parts/TypePart.php
+++ b/src/parts/TypePart.php
@@ -1,6 +1,7 @@
 <?php
 namespace gossi\swagger\parts;
 
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\Map;
 
 trait TypePart {
@@ -21,13 +22,13 @@ trait TypePart {
 	private $maximum;
 
 	/** @var bool */
-	private $exclusiveMaximum = false;
+	private $exclusiveMaximum;
 
 	/** @var float */
 	private $minimum;
 
 	/** @var bool */
-	private $exclusiveMinimum = false;
+	private $exclusiveMinimum;
 
 	/** @var int */
 	private $maxLength;
@@ -59,17 +60,36 @@ trait TypePart {
 		$this->collectionFormat = $data->get('collectionFormat');
 		$this->default = $data->get('default');
 		$this->maximum = $data->get('maximum');
-		$this->exclusiveMaximum = $data->has('exclusiveMaximum') && $data->get('exclusiveMaximum');
+		$this->exclusiveMaximum = $data->get('exclusiveMaximum');
 		$this->minimum = $data->get('minimum');
-		$this->exclusiveMinimum = $data->has('exclusiveMinimum') && $data->get('exclusiveMinimum');
+		$this->exclusiveMinimum = $data->get('exclusiveMinimum');
 		$this->maxLength = $data->get('maxLength');
 		$this->minLength = $data->get('minLength');
 		$this->pattern = $data->get('pattern');
 		$this->maxItems = $data->get('maxItems');
 		$this->minItems = $data->get('minItems');
-		$this->uniqueItems = $data->has('uniqueItems') && $data->get('uniqueItems');
+		$this->uniqueItems = $data->get('uniqueItems');
 		$this->enum = $data->get('enum');
 		$this->multipleOf = $data->get('multipleOf');
+	}
+
+	private function mergeType(static $model, $overwrite = false) {
+		MergeHelper::mergeFields($this->type, $model->type, $overwrite);
+		MergeHelper::mergeFields($this->format, $model->format, $overwrite);
+		MergeHelper::mergeFields($this->collectionFormat, $model->collectionFormat, $overwrite);
+		MergeHelper::mergeFields($this->default, $model->default, $overwrite);
+		MergeHelper::mergeFields($this->maximum, $model->maximum, $overwrite);
+		MergeHelper::mergeFields($this->exclusiveMaximum, $model->exclusiveMaximum, $overwrite);
+		MergeHelper::mergeFields($this->minimum, $model->minimum, $overwrite);
+		MergeHelper::mergeFields($this->exclusiveMinimum, $model->exclusiveMinimum, $overwrite);
+		MergeHelper::mergeFields($this->maxLength, $model->maxLength, $overwrite);
+		MergeHelper::mergeFields($this->minLength, $model->minLength, $overwrite);
+		MergeHelper::mergeFields($this->pattern, $model->pattern, $overwrite);
+		MergeHelper::mergeFields($this->maxItems, $model->maxItems, $overwrite);
+		MergeHelper::mergeFields($this->minItems, $model->minItems, $overwrite);
+		MergeHelper::mergeFields($this->uniqueItems, $model->uniqueItems, $overwrite);
+		MergeHelper::mergeFields($this->enum, $model->enum, $overwrite);
+		MergeHelper::mergeFields($this->multipleOf, $model->multipleOf, $overwrite);
 	}
 
 	private function getTypeExportFields() {
@@ -126,17 +146,17 @@ trait TypePart {
 
 	/**
 	 * Determines the format of the array if type array is used. Possible values are:
-	 * 
+	 *
 	 * - `csv` - comma separated values `foo,bar`.
 	 * - `ssv` - space separated values `foo bar`.
 	 * - `tsv` - tab separated values `foo\tbar`.
 	 * - `pipes` - pipe separated values `foo|bar`.
-	 * - `multi` - corresponds to multiple parameter instances instead of multiple values for a 
+	 * - `multi` - corresponds to multiple parameter instances instead of multiple values for a
 	 * single instance `foo=bar&foo=baz`. This is valid only for parameters in "query" or "formData".
-	 * 
+	 *
 	 * Default value is `csv`.
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $collectionFormat
 	 * @return $this
 	 */
@@ -186,7 +206,7 @@ trait TypePart {
 	 * @return bool
 	 */
 	public function isExclusiveMaximum() {
-		return $this->exclusiveMaximum;
+		return null !== $this->exclusiveMaximum ? $this->exclusiveMaximum : false;
 	}
 
 	/**
@@ -222,7 +242,7 @@ trait TypePart {
 	 * @return bool
 	 */
 	public function isExclusiveMinimum() {
-		return $this->exclusiveMinimum;
+		return null !== $this->exclusiveMinimum ? $this->exclusiveMinimum : false;
 	}
 
 	/**

--- a/src/parts/UrlPart.php
+++ b/src/parts/UrlPart.php
@@ -1,15 +1,20 @@
 <?php
 namespace gossi\swagger\parts;
 
+use gossi\swagger\util\MergeHelper;
 use phootwork\collection\Map;
 
 trait UrlPart {
 
 	/** @var string */
-	private $url = false;
+	private $url;
 
 	private function parseUrl(Map $data) {
 		$this->url = $data->get('url');
+	}
+
+	private function mergeUrl(static $model, $overwrite = false) {
+		MergeHelper::mergeFields($this->url, $model->url, $overwrite);
 	}
 
 	/**

--- a/src/util/MergeHelper.php
+++ b/src/util/MergeHelper.php
@@ -1,0 +1,35 @@
+<?php
+namespace gossi\swagger\util;
+
+use phootwork\collection\Map;
+use phootwork\collection\Set;
+
+/**
+ * @internal
+ */
+class MergeHelper {
+    /**
+     * @param string|integer|null|Map|Set $original
+     * @param string|integer|null|Map|Set $external
+     * @param bool                $overwrite
+     */
+    public static function mergeFields(&$original, $external, $overwrite) {
+        if ($original instanceof Map) {
+            foreach ($external as $key => $value) {
+                if ($overwrite || !$original->has($key)) {
+                    $original->set($key, $value);
+                }
+            }
+        } elseif ($original instanceof Set) {
+            foreach ($external as $value) {
+                $original->add($value);
+            }
+        } else { // if scalar
+            if ($overwrite) {
+                $original = null !== $external ? $external : $original;
+            } else {
+                $original = null === $original ? $external : $original;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR would allow to merge models with two different strategies:
- `PREFER_ORIGINAL` which would keep the original fields except if they aren't defined yet.
- `PREFER_EXTERNAL` which would use the provided fields when they are available.

This is useful when you want to merge different documentations or in my case to merge the output of different libraries generating the doc of an app.
