### PR TITLE
Casts object to string before passing to collection

### DIFF
--- a/src/parts/ExtensionPart.php
+++ b/src/parts/ExtensionPart.php
@@ -14,7 +14,7 @@ trait ExtensionPart {
 		foreach ($data as $k => $v) {
 			$key = new Text($k);
 			if ($key->startsWith('x-')) {
-				$this->extensions->set($key->substring(2), $v);
+				$this->extensions->set((string) $key->substring(2), $v);
 			}
 		}
 	}


### PR DESCRIPTION
Casts object of type phootwork\lang\Text to string before passing
off to phootwork\collection\Map::set(). This method expects a
string and, when given an object, errors with offset warning
(silly arrays, amirite?)
