### PR TITLE
Adds security defs to exported array

### DIFF
--- a/src/Swagger.php
+++ b/src/Swagger.php
@@ -121,7 +121,7 @@ class Swagger extends AbstractModel implements Arrayable {
 
 	public function toArray() {
 		return $this->export('swagger', 'info', 'host', 'basePath', 'schemes', 'consumes', 'produces',
-			'paths', 'definitions', 'parameters', 'responses', 'tags', 'externalDocs'
+			'securityDefinitions', 'paths', 'definitions', 'parameters', 'responses', 'tags', 'externalDocs'
 		);
 	}
 


### PR DESCRIPTION
Using Swagger::toArray to return a generated swagger doc results
in a missing security definitions. Not sure if this method is
meant for something special, but this behavior is stripping out
important data for my integration.
