### PR TITLE
Export security defs

### DIFF
--- a/src/Operation.php
+++ b/src/Operation.php
@@ -8,6 +8,7 @@ use gossi\swagger\parts\ParametersPart;
 use gossi\swagger\parts\ProducesPart;
 use gossi\swagger\parts\ResponsesPart;
 use gossi\swagger\parts\SchemesPart;
+use gossi\swagger\parts\SecurityPart;
 use gossi\swagger\parts\TagsPart;
 use phootwork\collection\CollectionUtils;
 use phootwork\lang\Arrayable;
@@ -17,6 +18,7 @@ class Operation extends AbstractModel implements Arrayable {
 	use ConsumesPart;
 	use ProducesPart;
 	use TagsPart;
+	use SecurityPart;
 	use ParametersPart;
 	use ResponsesPart;
 	use SchemesPart;
@@ -51,6 +53,7 @@ class Operation extends AbstractModel implements Arrayable {
 		$this->parseConsumes($data);
 		$this->parseProduces($data);
 		$this->parseTags($data);
+		$this->parseSecurity($data);
 		$this->parseParameters($data);
 		$this->parseResponses($data);
 		$this->parseSchemes($data);
@@ -60,8 +63,8 @@ class Operation extends AbstractModel implements Arrayable {
 
 	public function toArray() {
 		return $this->export('summary', 'description', 'operationId', 'deprecated',
-				'consumes', 'produces', 'parameters', 'responses', 'schemes', 'tags',
-				'externalDocs');
+				'consumes', 'produces', 'security', 'parameters', 'responses', 'schemes',
+				'tags', 'externalDocs');
 	}
 
 	/**

--- a/src/SecurityScheme.php
+++ b/src/SecurityScheme.php
@@ -11,16 +11,30 @@ class SecurityScheme extends AbstractModel implements Arrayable {
 	/** @var string */
 	private $type;
 
+	/** @var string */
+	private $description;
+
+	/**
+	 * @param string $name
+	 * @param array $contents
+	 */
 	public function __construct($name, $contents = []) {
 		$this->name = $name;
 		$this->parse($contents);
 	}
 
+	/**
+	 * @param array $contents
+	 */
 	private function parse($contents = []) {
 		$this->type = $contents->get('type');
+		$this->description = $contents->get('description');
 	}
 
+	/**
+	 * @return array
+	 */
 	public function toArray() {
-		return $this->export('type');
+		return $this->export('type', 'description');
 	}
 }

--- a/src/SecurityScheme.php
+++ b/src/SecurityScheme.php
@@ -1,10 +1,15 @@
 <?php
 namespace gossi\swagger;
 
-class SecurityScheme {
+use phootwork\lang\Arrayable;
+
+class SecurityScheme extends AbstractModel implements Arrayable {
 
 	/** @var string */
 	private $name;
+
+	/** @var string */
+	private $type;
 
 	public function __construct($name, $contents = []) {
 		$this->name = $name;
@@ -12,6 +17,10 @@ class SecurityScheme {
 	}
 
 	private function parse($contents = []) {
+		$this->type = $contents->get('type');
+	}
 
+	public function toArray() {
+		return $this->export('type');
 	}
 }

--- a/src/Swagger.php
+++ b/src/Swagger.php
@@ -121,7 +121,7 @@ class Swagger extends AbstractModel implements Arrayable {
 
 	public function toArray() {
 		return $this->export('swagger', 'info', 'host', 'basePath', 'schemes', 'consumes', 'produces',
-			'paths', 'definitions', 'parameters', 'responses', 'tags', 'externalDocs'
+			'securityDefinitions', 'paths', 'definitions', 'parameters', 'responses', 'tags', 'externalDocs'
 		);
 	}
 

--- a/src/parts/SecurityPart.php
+++ b/src/parts/SecurityPart.php
@@ -1,0 +1,31 @@
+<?php
+namespace gossi\swagger\parts;
+
+use phootwork\collection\Map;
+
+trait SecurityPart {
+
+	/** @var object */
+	private $security;
+
+	private function parseSecurity(Map $data) {
+		$this->security = $data->get('security');
+	}
+
+	/**
+	 * @return object
+	 */
+	public function getSecurity() {
+		return $this->security;
+	}
+
+	/**
+	 * @param object $security
+	 * @return $this
+	 */
+	public function setSecurity($security) {
+		$this->security = $security;
+		return $this;
+	}
+
+}

--- a/tests/BasicAuthTest.php
+++ b/tests/BasicAuthTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace gossi\swagger\tests;
+
+use gossi\swagger\Swagger;
+use phootwork\file\exception\FileNotFoundException;
+use phootwork\file\File;
+use phootwork\json\Json;
+
+class BasicAuth extends \PHPUnit_Framework_TestCase {
+
+	private function fileToArray($filename) {
+		$file = new File($filename);
+
+		if (!$file->exists()) {
+			throw new FileNotFoundException(sprintf('File not found at: %s', $filename));
+		}
+
+		return Json::decode($file->read());
+	}
+
+	public function testUser() {
+		$filename = __DIR__ . '/fixtures/basic-auth.json';
+		$swagger = Swagger::fromFile($filename);
+
+		$this->assertEquals($this->fileToArray($filename), $swagger->toArray());
+	}
+}

--- a/tests/fixtures/basic-auth.json
+++ b/tests/fixtures/basic-auth.json
@@ -1,0 +1,35 @@
+{
+	"swagger": "2.0",
+	"info": {
+		"version": "1.0.0",
+		"title": "Basic Auth Example",
+		"description": "An example for how to use Basic Auth with Swagger.\nServer code is available [here](https://github.com/mohsen1/basic-auth-server). It's running on Heroku.\n\n**User Name and Password**\n* User Name: `user`\n* Password: `pass`\n"
+	},
+	"host": "basic-auth-server.herokuapp.com",
+	"schemes": [
+		"http",
+		"https"
+	],
+	"securityDefinitions": {
+		"basicAuth": {
+			"type": "basic",
+			"description": "HTTP Basic Authentication. Works over `HTTP` and `HTTPS`"
+		}
+	},
+	"paths": {
+		"/": {
+			"get": {
+				"security": [
+					{
+						"basicAuth": []
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Will send `Authenticated` if authentication is succesful, otherwise it will send `Unauthorized`"
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds securityDefinitions and per-operation security attributes for 'Basic Auth'. Also adds a test based off the basicAuth example.

Note: not sure how this works with other types of security because my use case doesn't include them ;)
